### PR TITLE
[FEAT] language setting을 가져오는 command 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ require('dotenv').config();
 
 
 const bot = new Eris(process.env.DISCORD_BOT_TOKEN);
+const Constants = Eris.Constants;
 
 const SENTENCE_INTERVAL = 500;
 
@@ -46,6 +47,37 @@ bot.on("ready", () => {
 bot.on("messageCreate", (msg) => {
     if(msg.content === "!ping") {
         bot.createMessage(msg.channel.id, "Pong!");
+    } else if (msg.content == "!language"){
+        bot.createMessage(msg.channel.id, {
+            content: "Choose your language!",
+            components: [
+                {
+                    type: Constants.ComponentTypes.ACTION_ROW,
+                    components: [
+                        {   type: Constants.ComponentTypes.BUTTON,
+                            style: Constants.ButtonStyles.PRIMARY,
+                            custom_id: "ko",
+                            label: "한국어",
+                            disabled: false
+                        },
+                        {
+                            type: Constants.ComponentTypes.BUTTON,
+                            style: Constants.ButtonStyles.PRIMARY,
+                            custom_id: "en",
+                            label: "English",
+                            disabled: false
+                        },
+                        {
+                            type: Constants.ComponentTypes.BUTTON,
+                            style: Constants.ButtonStyles.PRIMARY,
+                            custom_id: "tr",
+                            label: "Türkçe",
+                            disabled: false
+                        }
+                    ]
+                }
+            ]
+        }); 
     } else if (msg.content === "!join") {
         if (!msg.member.voiceState.channelID) {
             bot.createMessage(msg.channel.id, "You are not in a voice channel.");
@@ -74,7 +106,7 @@ bot.on("messageCreate", (msg) => {
                 })
             })
         } 
-    }  else if (msg.content === "!leave") {
+    } else if (msg.content === "!leave") {
         if (!msg.member.voiceState.channelID) {
             bot.createMessage(msg.channel.id, "You are not in a voice channel.");
             return;
@@ -85,4 +117,32 @@ bot.on("messageCreate", (msg) => {
     }
 });
 
+bot.on("interactionCreate", (interaction) => {
+    if(interaction instanceof Eris.ComponentInteraction) { 
+        if(interaction.data.custom_id === "ko") {
+            return interaction.createMessage({
+                    content: `<@${interaction.member.user.id}> 한국어로 설정되었습니다.`, 
+                    allowedMentions: {
+                        users: [interaction.member.user.id]
+                    }
+            })
+        } else if (interaction.data.custom_id === "en") {
+            return interaction.createMessage({
+                content: `<@${interaction.member.user.id}> English is set.`,
+                allowedMentions: {
+                    users: [interaction.member.user.id]
+                }
+            })
+        } else if (interaction.data.custom_id === "tr") {
+            return interaction.createMessage({
+                content:   `<@${interaction.member.user.id}> Türkçe olarak ayarlandı.`,
+                allowedMentions: {
+                    users: [interaction.member.user.id]
+                }
+            })
+        }
+    }
+});
+
 bot.connect();
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,17 @@ const path = require("path");
 require('dotenv').config();
 
 
-const bot = new Eris(process.env.DISCORD_BOT_TOKEN);
+const bot = new Eris(process.env.DISCORD_BOT_TOKEN, {
+    getAllUsers: true,
+    intents: 98303	
+});
+
 const Constants = Eris.Constants;
 
 const SENTENCE_INTERVAL = 500;
 
 const userVoiceDataMap = new Map();
+const memberMap = new Map();
 
 bot.on("ready", () => {
     console.log("Ready!");
@@ -42,6 +47,15 @@ bot.on("ready", () => {
           }
         });
       }, SENTENCE_INTERVAL);
+
+    //get all users in the guild initially
+    bot.users.forEach((user) => {
+        if (!memberMap.has(user.id) && !user.bot)
+            memberMap.set(user.id, {
+                id: user.id,
+                name: user.username,
+            });
+    });
 });
 
 bot.on("messageCreate", (msg) => {


### PR DESCRIPTION
- !language 로 유저와 버튼으로 interaction하여 현재 언어 세팅을 선택
- bot이 처음 생성될 때 guild 안의 모든 member 정보 가져옴
- member 정보를 갖고오기위해 bot에게 권한 추가

To-Do
- [ ] interaction을 통해 가져온 유저의 language 세팅을 memberMap 에 매핑해 저장
- [ ] voice channel 에 접속한 모든 user의 언어 설정을 가져오기 전에는 !join 명령어를 실행할 수 없도록 설정
- [ ] 새로운 user가 guild에 join하는 이벤트가 발생했을 때, 해당 user 정보를 가져와 memberMap에 추가